### PR TITLE
UV情報の無い頂点が面情報に出力されないバグを修正

### DIFF
--- a/CM3D2 Converter/model_export.py
+++ b/CM3D2 Converter/model_export.py
@@ -478,8 +478,7 @@ class export_cm3d2_model(bpy.types.Operator):
 								if v[0] == index:
 									vert_index = i
 									break
-						else:
-							faces.append(vert_index)
+						faces.append(vert_index)
 					face_count += 1
 				elif len(face.verts) == 4 and self.is_convert_tris:
 					v1 = face.loops[0].vert.co - face.loops[2].vert.co


### PR DESCRIPTION
UV情報が無いエラーの廃止 12da6cd6 に対する修正です。
