### PR TITLE
バックアップファイル名に元ファイルの拡張子を残す

### DIFF
--- a/CM3D2 Converter/model_export.py
+++ b/CM3D2 Converter/model_export.py
@@ -325,8 +325,7 @@ class export_cm3d2_model(bpy.types.Operator):
 		# バックアップ
 		if self.is_backup and context.user_preferences.addons[__name__.split('.')[0]].preferences.backup_ext:
 			if os.path.exists(self.filepath):
-				root, ext = os.path.splitext(self.filepath)
-				backup_path = root + "." + context.user_preferences.addons[__name__.split('.')[0]].preferences.backup_ext
+				backup_path = self.filepath + "." + context.user_preferences.addons[__name__.split('.')[0]].preferences.backup_ext
 				shutil.copyfile(self.filepath, backup_path)
 				self.report(type={'INFO'}, message="上書き時にバックアップを複製しました")
 		


### PR DESCRIPTION
バックアップファイル名に対して、元の拡張子(.model)をわざわざ削除しなくてもよいのではないでしょうか。
