### PR TITLE
バッチ実行を可能にする

### DIFF
--- a/CM3D2 Converter/model_export.py
+++ b/CM3D2 Converter/model_export.py
@@ -41,7 +41,7 @@ class export_cm3d2_model(bpy.types.Operator):
 	
 	is_batch = bpy.props.BoolProperty(name="バッチモード", default=False, description="モードの切替やエラー個所の選択を行いません")
 	
-	def invoke(self, context, event):
+	def precheck(self, context):
 		# データの成否チェック
 		ob = context.active_object
 		if not ob:
@@ -82,6 +82,12 @@ class export_cm3d2_model(bpy.types.Operator):
 				bpy.ops.object.mode_set(mode='EDIT')
 			self.report(type={'ERROR'}, message="五角以上のポリゴンが含まれています")
 			return {'CANCELLED'}
+		return None
+		
+	def invoke(self, context, event):
+		res = self.precheck(context)
+		if res: return res
+		ob = context.active_object
 		
 		# model名とか
 		ob_names = common.remove_serial_number(ob.name, self.is_arrange_name).split('.')
@@ -146,6 +152,9 @@ class export_cm3d2_model(bpy.types.Operator):
 		context.window_manager.progress_begin(0, 100)
 		context.window_manager.progress_update(0)
 		
+		res = self.precheck(context)
+		if res: return res
+
 		ob = context.active_object
 		me = ob.data
 		

--- a/CM3D2 Converter/model_export.py
+++ b/CM3D2 Converter/model_export.py
@@ -163,48 +163,31 @@ class export_cm3d2_model(bpy.types.Operator):
 			if "BoneData" not in context.blend_data.texts.keys():
 				self.report(type={'ERROR'}, message="テキスト「BoneData」が見つかりません、中止します")
 				return {'CANCELLED'}
-			elif "LocalBoneData" not in context.blend_data.texts.keys():
+			if "LocalBoneData" not in context.blend_data.texts.keys():
 				self.report(type={'ERROR'}, message="テキスト「LocalBoneData」が見つかりません、中止します")
 				return {'CANCELLED'}
 		elif self.bone_info_mode == 'OBJECT':
 			if "BoneData:0" not in ob.keys():
 				self.report(type={'ERROR'}, message="オブジェクトのカスタムプロパティにボーン情報がありません")
 				return {'CANCELLED'}
-			elif "LocalBoneData:0" not in ob.keys():
+			if "LocalBoneData:0" not in ob.keys():
 				self.report(type={'ERROR'}, message="オブジェクトのカスタムプロパティにボーン情報がありません")
 				return {'CANCELLED'}
 		elif self.bone_info_mode == 'ARMATURE':
 			arm_ob = ob.parent
-			if arm_ob:
-				if arm_ob.type == 'ARMATURE':
-					if "BoneData:0" not in arm_ob.data.keys():
-						self.report(type={'ERROR'}, message="アーマチュアのカスタムプロパティにボーン情報がありません")
-						return {'CANCELLED'}
-					elif "LocalBoneData:0" not in arm_ob.data.keys():
-						self.report(type={'ERROR'}, message="アーマチュアのカスタムプロパティにボーン情報がありません")
-						return {'CANCELLED'}
-				else:
-					self.report(type={'ERROR'}, message="メッシュオブジェクトの親がアーマチュアではありません")
-					return {'CANCELLED'}
-			else:
-				for mod in ob.modifiers:
-					if mod.type == 'ARMATURE':
-						if mod.object:
-							arm_ob = mod.object
-							if "BoneData:0" not in arm_ob.data.keys():
-								self.report(type={'ERROR'}, message="アーマチュアのカスタムプロパティにボーン情報がありません")
-								return {'CANCELLED'}
-							elif "LocalBoneData:0" not in arm_ob.data.keys():
-								self.report(type={'ERROR'}, message="アーマチュアのカスタムプロパティにボーン情報がありません")
-								return {'CANCELLED'}
-							break
-				else:
+			if arm_ob and arm_ob.type != 'ARMATURE':
+				self.report(type={'ERROR'}, message="メッシュオブジェクトの親がアーマチュアではありません")
+				return {'CANCELLED'}
+			if not arm_ob:
+				try:
+					arm_ob = next(mod for mod in ob.modifiers if mod.type == 'ARMATURE' and mod.object)
+				except StopIteration:
 					self.report(type={'ERROR'}, message="アーマチュアが見つかりません、親にするかモディファイアにして下さい")
 					return {'CANCELLED'}
 			if "BoneData:0" not in arm_ob.data.keys():
 				self.report(type={'ERROR'}, message="アーマチュアのカスタムプロパティにボーン情報がありません")
 				return {'CANCELLED'}
-			elif "LocalBoneData:0" not in arm_ob.data.keys():
+			if "LocalBoneData:0" not in arm_ob.data.keys():
 				self.report(type={'ERROR'}, message="アーマチュアのカスタムプロパティにボーン情報がありません")
 				return {'CANCELLED'}
 		else:

--- a/CM3D2 Converter/model_export.py
+++ b/CM3D2 Converter/model_export.py
@@ -39,6 +39,8 @@ class export_cm3d2_model(bpy.types.Operator):
 	is_normalize_weight = bpy.props.BoolProperty(name="ウェイトの合計を1.0に", default=True, description="4つのウェイトの合計値が1.0になるように正規化します")
 	is_convert_vertex_group_names = bpy.props.BoolProperty(name="頂点グループ名をCM3D2用に変換", default=True, description="全ての頂点グループ名をCM3D2で使える名前にしてからエクスポートします")
 	
+	is_batch = bpy.props.BoolProperty(name="バッチモード", default=False, description="モードの切替やエラー個所の選択を行いません")
+	
 	def invoke(self, context, event):
 		# データの成否チェック
 		ob = context.active_object
@@ -68,18 +70,18 @@ class export_cm3d2_model(bpy.types.Operator):
 		if 65535 < len(me.vertices):
 			self.report(type={'ERROR'}, message="エクスポート可能な頂点数を大幅に超えています、最低でも65535未満には削減してください")
 			return {'CANCELLED'}
-		for face in me.polygons:
-			if 5 <= len(face.vertices):
+		pentagons = [face for face in me.polygons if 5 <= len(face.vertices)]
+		if 0 < len(pentagons):
+			if not self.is_batch:
 				bpy.ops.object.mode_set(mode='EDIT')
 				bpy.ops.mesh.select_all(action='DESELECT')
 				bpy.ops.object.mode_set(mode='OBJECT')
 				context.tool_settings.mesh_select_mode = (False, False, True)
-				for face in me.polygons:
-					if 5 <= len(face.vertices):
-						face.select = True
+				for face in pentagons:
+					face.select = True
 				bpy.ops.object.mode_set(mode='EDIT')
-				self.report(type={'ERROR'}, message="五角以上のポリゴンが含まれています")
-				return {'CANCELLED'}
+			self.report(type={'ERROR'}, message="五角以上のポリゴンが含まれています")
+			return {'CANCELLED'}
 		
 		# model名とか
 		ob_names = common.remove_serial_number(ob.name, self.is_arrange_name).split('.')
@@ -133,11 +135,14 @@ class export_cm3d2_model(bpy.types.Operator):
 		sub_box = box.box()
 		sub_box.prop(self, 'is_normalize_weight', icon='MOD_VERTEX_WEIGHT')
 		sub_box.prop(self, 'is_convert_vertex_group_names', icon='GROUP_VERTEX')
+		# don't show 'is_batch' in UI
 	
 	def execute(self, context):
 		start_time = time.time()
 		
-		context.user_preferences.addons[__name__.split('.')[0]].preferences.model_export_path = self.filepath
+		if not self.is_batch:
+			context.user_preferences.addons[__name__.split('.')[0]].preferences.model_export_path = self.filepath
+		
 		context.window_manager.progress_begin(0, 100)
 		context.window_manager.progress_update(0)
 		
@@ -355,7 +360,8 @@ class export_cm3d2_model(bpy.types.Operator):
 			file.write(struct.pack('<4f', bone['rot'][1], bone['rot'][2], bone['rot'][3], bone['rot'][0]))
 		context.window_manager.progress_update(4)
 		
-		bpy.ops.object.mode_set(mode='OBJECT')
+		if not self.is_batch:
+			bpy.ops.object.mode_set(mode='OBJECT')
 		
 		# 正しい頂点数などを取得
 		bm = bmesh.new()
@@ -422,20 +428,21 @@ class export_cm3d2_model(bpy.types.Operator):
 				if 0.0 < weight:
 					vgs.append([name, weight])
 			if len(vgs) == 0:
-				bpy.ops.object.mode_set(mode='EDIT')
-				bpy.ops.mesh.select_all(action='DESELECT')
-				bpy.ops.object.mode_set(mode='OBJECT')
-				context.tool_settings.mesh_select_mode = (True, False, False)
-				for vert in me.vertices:
-					for vg in vert.groups:
-						name = common.encode_bone_name(ob.vertex_groups[vg.group].name, self.is_convert_vertex_group_names)
-						if name not in local_bone_names:
-							continue
-						if 0.0 < vg.weight:
-							break
-					else:
-						vert.select = True
-				bpy.ops.object.mode_set(mode='EDIT')
+				if not self.is_batch:
+					bpy.ops.object.mode_set(mode='EDIT')
+					bpy.ops.mesh.select_all(action='DESELECT')
+					bpy.ops.object.mode_set(mode='OBJECT')
+					context.tool_settings.mesh_select_mode = (True, False, False)
+					for vert in me.vertices:
+						for vg in vert.groups:
+							name = common.encode_bone_name(ob.vertex_groups[vg.group].name, self.is_convert_vertex_group_names)
+							if name not in local_bone_names:
+								continue
+							if 0.0 < vg.weight:
+								break
+						else:
+							vert.select = True
+					bpy.ops.object.mode_set(mode='EDIT')
 				self.report(type={'ERROR'}, message="ウェイトが割り当てられていない頂点が見つかりました、中止します")
 				return {'CANCELLED'}
 			vgs.sort(key=lambda vg: vg[1])


### PR DESCRIPTION
エラー時のモード切替、メッシュの自動選択などの処理が増えたため、外部スクリプトからバッチとして実行した場合にエラーが発生していました。

以下のように `is_batch=True` として呼び出すことで実行可能にしました。
バッチ用のフラグのため、`default=False` で UI にチェックボックスは追加していません。

``` python
bpy.ops.export_mesh.export_cm3d2_model(filepath=filename, is_batch=True)
```

また、バッチ時は `invoke()` を呼び出さないため、一部のエラーチェックを別メソッドに分離しました。
