### PR TITLE
collection 内の key 存在チェック時に _.keys() を使用しない。

### DIFF
--- a/CM3D2 Converter/anm_import.py
+++ b/CM3D2 Converter/anm_import.py
@@ -75,7 +75,7 @@ class import_cm3d2_anm(bpy.types.Operator):
 			path = common.read_str(file)
 			
 			base_bone_name = path.split('/')[-1]
-			if base_bone_name not in anm_data.keys():
+			if base_bone_name not in anm_data:
 				anm_data[base_bone_name] = {'path':path}
 				anm_data[base_bone_name]['channels'] = {}
 			
@@ -110,9 +110,9 @@ class import_cm3d2_anm(bpy.types.Operator):
 		max_frame = 0
 		bpy.ops.object.mode_set(mode='OBJECT')
 		for bone_name, bone_data in anm_data.items():
-			if bone_name not in pose.bones.keys():
+			if bone_name not in pose.bones:
 				bone_name = common.decode_bone_name(bone_name)
-				if bone_name not in pose.bones.keys():
+				if bone_name not in pose.bones:
 					continue
 			bone = arm.bones[bone_name]
 			pose_bone = pose.bones[bone_name]
@@ -124,7 +124,7 @@ class import_cm3d2_anm(bpy.types.Operator):
 				if channel_id in [100, 101, 102, 103]:
 					for data in channel_data:
 						frame = data['frame']
-						if frame not in quats.keys():
+						if frame not in quats:
 							quats[frame] = [None, None, None, None]
 						
 						if channel_id == 103:
@@ -139,7 +139,7 @@ class import_cm3d2_anm(bpy.types.Operator):
 				elif channel_id in [104, 105, 106]:
 					for data in channel_data:
 						frame = data['frame']
-						if frame not in locs.keys():
+						if frame not in locs:
 							locs[frame] = [None, None, None]
 						
 						if channel_id == 104:

--- a/CM3D2 Converter/common.py
+++ b/CM3D2 Converter/common.py
@@ -46,7 +46,7 @@ def decode_bone_name(name, enable=True):
 # CM3D2用マテリアルを設定に合わせて装飾
 def decorate_material(mate, enable=True, me=None, mate_index=-1):
 	if not enable: return
-	if 'shader1' not in mate.keys(): return
+	if 'shader1' not in mate: return
 	
 	shader = mate['shader1']
 	if 'CM3D2/Man' == shader:
@@ -135,7 +135,7 @@ def decorate_material(mate, enable=True, me=None, mate_index=-1):
 		mate_node.location = (0, 0)
 		mate_node.material = mate
 		
-		if "CM3D2 Shade" in bpy.context.blend_data.materials.keys():
+		if "CM3D2 Shade" in bpy.context.blend_data.materials:
 			shade_mate = bpy.context.blend_data.materials["CM3D2 Shade"]
 		else:
 			shade_mate = bpy.context.blend_data.materials.new("CM3D2 Shade")
@@ -499,7 +499,7 @@ def remove_data(target_data):
 	
 	for data in target_data:
 		if data.__class__.__name__ == 'Object':
-			if data.name in bpy.context.scene.objects.keys():
+			if data.name in bpy.context.scene.objects:
 				bpy.context.scene.objects.unlink(data)
 	
 	for data in target_data:

--- a/CM3D2 Converter/mate_export.py
+++ b/CM3D2 Converter/mate_export.py
@@ -22,7 +22,7 @@ class export_cm3d2_mate(bpy.types.Operator):
 		if 'material' in dir(context):
 			mate = context.material
 			if mate:
-				if 'shader1' in mate.keys() and 'shader2' in mate.keys():
+				if 'shader1' in mate and 'shader2' in mate:
 					return True
 		return False
 	
@@ -90,7 +90,7 @@ class export_cm3d2_mate(bpy.types.Operator):
 				if img:
 					common.write_str(file, 'tex2d')
 					common.write_str(file, common.remove_serial_number(img.name))
-					if 'cm3d2_path' in img.keys():
+					if 'cm3d2_path' in img:
 						path = img['cm3d2_path']
 					else:
 						path = bpy.path.abspath(img.filepath)

--- a/CM3D2 Converter/misc_DATA_PT_context_arm.py
+++ b/CM3D2 Converter/misc_DATA_PT_context_arm.py
@@ -12,7 +12,7 @@ def menu_func(self, context):
 	is_boxed = False
 	
 	bone_data_count = 0
-	if 'BoneData:0' in arm.keys() and 'LocalBoneData:0' in arm.keys():
+	if 'BoneData:0' in arm and 'LocalBoneData:0' in arm:
 		for key in arm.keys():
 			if re.search(r'^(Local)?BoneData:\d+$', key):
 				bone_data_count += 1
@@ -60,7 +60,7 @@ def menu_func(self, context):
 			row.operator('armature.encode_cm3d2_bone_names', text="Blender → CM3D2", icon_value=common.preview_collections['main']['KISS'].icon_id)
 			break
 	
-	if 'is T Stance' in arm.keys():
+	if 'is T Stance' in arm:
 		if not is_boxed:
 			box = self.layout.box()
 			box.label(text="CM3D2用", icon_value=common.preview_collections['main']['KISS'].icon_id)
@@ -160,7 +160,7 @@ class copy_armature_bone_data_property(bpy.types.Operator):
 		if ob:
 			if ob.type == 'ARMATURE':
 				arm = ob.data
-				if 'BoneData:0' in arm.keys() and 'LocalBoneData:0' in arm.keys():
+				if 'BoneData:0' in arm and 'LocalBoneData:0' in arm:
 					return True
 		return False
 	
@@ -168,11 +168,11 @@ class copy_armature_bone_data_property(bpy.types.Operator):
 		output_text = ""
 		ob = context.active_object.data
 		pass_count = 0
-		if 'BaseBone' in ob.keys():
+		if 'BaseBone' in ob:
 			output_text += "BaseBone:" + ob['BaseBone'] + "\n"
 		for i in range(99999):
 			name = "BoneData:" + str(i)
-			if name in ob.keys():
+			if name in ob:
 				output_text += "BoneData:" + ob[name] + "\n"
 			else:
 				pass_count += 1
@@ -181,7 +181,7 @@ class copy_armature_bone_data_property(bpy.types.Operator):
 		pass_count = 0
 		for i in range(99999):
 			name = "LocalBoneData:" + str(i)
-			if name in ob.keys():
+			if name in ob:
 				output_text += "LocalBoneData:" + ob[name] + "\n"
 			else:
 				pass_count += 1
@@ -213,7 +213,7 @@ class paste_armature_bone_data_property(bpy.types.Operator):
 		pass_count = 0
 		for i in range(99999):
 			name = "BoneData:" + str(i)
-			if name in ob.keys():
+			if name in ob:
 				del ob[name]
 			else:
 				pass_count += 1
@@ -222,7 +222,7 @@ class paste_armature_bone_data_property(bpy.types.Operator):
 		pass_count = 0
 		for i in range(99999):
 			name = "LocalBoneData:" + str(i)
-			if name in ob.keys():
+			if name in ob:
 				del ob[name]
 			else:
 				pass_count += 1
@@ -263,7 +263,7 @@ class remove_armature_bone_data_property(bpy.types.Operator):
 		if ob:
 			if ob.type == 'ARMATURE':
 				arm = ob.data
-				if 'BoneData:0' in arm.keys() and 'LocalBoneData:0' in arm.keys():
+				if 'BoneData:0' in arm and 'LocalBoneData:0' in arm:
 					return True
 		return False
 	
@@ -276,11 +276,11 @@ class remove_armature_bone_data_property(bpy.types.Operator):
 	def execute(self, context):
 		ob = context.active_object.data
 		pass_count = 0
-		if 'BaseBone' in ob.keys():
+		if 'BaseBone' in ob:
 			del ob['BaseBone']
 		for i in range(99999):
 			name = "BoneData:" + str(i)
-			if name in ob.keys():
+			if name in ob:
 				del ob[name]
 			else:
 				pass_count += 1
@@ -289,7 +289,7 @@ class remove_armature_bone_data_property(bpy.types.Operator):
 		pass_count = 0
 		for i in range(99999):
 			name = "LocalBoneData:" + str(i)
-			if name in ob.keys():
+			if name in ob:
 				del ob[name]
 			else:
 				pass_count += 1

--- a/CM3D2 Converter/misc_DATA_PT_vertex_groups.py
+++ b/CM3D2 Converter/misc_DATA_PT_vertex_groups.py
@@ -50,7 +50,7 @@ class decode_cm3d2_vertex_group_names(bpy.types.Operator):
 			context.window_manager.progress_update(vg_index)
 			vg_name = common.decode_bone_name(vg.name)
 			if vg_name != vg.name:
-				if vg_name in ob.vertex_groups.keys():
+				if vg_name in ob.vertex_groups:
 					target_vg = ob.vertex_groups[vg_name]
 					for vert in me.vertices:
 						try:
@@ -101,7 +101,7 @@ class encode_cm3d2_vertex_group_names(bpy.types.Operator):
 			context.window_manager.progress_update(vg_index)
 			vg_name = common.encode_bone_name(vg.name)
 			if vg_name != vg.name:
-				if vg_name in ob.vertex_groups.keys():
+				if vg_name in ob.vertex_groups:
 					target_vg = ob.vertex_groups[vg_name]
 					for vert in me.vertices:
 						try:

--- a/CM3D2 Converter/misc_IMAGE_HT_header.py
+++ b/CM3D2 Converter/misc_IMAGE_HT_header.py
@@ -6,7 +6,7 @@ def menu_func(self, context):
 	if 'edit_image' in dir(context):
 		img = context.edit_image
 		if img:
-			if 'cm3d2_path' in img.keys():
+			if 'cm3d2_path' in img:
 				self.layout.label(text="CM3D2用: 内部パス", icon_value=common.preview_collections['main']['KISS'].icon_id)
 				row = self.layout.row()
 				row.prop(img, '["cm3d2_path"]', text="")

--- a/CM3D2 Converter/misc_IMAGE_PT_image_properties.py
+++ b/CM3D2 Converter/misc_IMAGE_PT_image_properties.py
@@ -5,7 +5,7 @@ from . import common
 def menu_func(self, context):
 	if 'edit_image' in dir(context):
 		img = context.edit_image
-		if 'cm3d2_path' in img.keys():
+		if 'cm3d2_path' in img:
 			box = self.layout.box()
 			box.label(text="CM3D2用", icon_value=common.preview_collections['main']['KISS'].icon_id)
 			box.prop(img, '["cm3d2_path"]', icon='ANIM_DATA', text="内部パス")

--- a/CM3D2 Converter/misc_MATERIAL_PT_context_material.py
+++ b/CM3D2 Converter/misc_MATERIAL_PT_context_material.py
@@ -11,7 +11,7 @@ def menu_func(self, context):
 		row.operator('material.import_cm3d2_mate', icon='FILE_FOLDER', text="mateから")
 		row.operator('material.paste_material', icon='PASTEDOWN', text="クリップボードから")
 	else:
-		if 'shader1' in mate.keys() and 'shader2' in mate.keys():
+		if 'shader1' in mate and 'shader2' in mate:
 			box = self.layout.box()
 			#row = box.split(percentage=0.3)
 			row = box.split(percentage=0.5)
@@ -78,7 +78,7 @@ def menu_func(self, context):
 			box.operator('material.decorate_material', icon='TEXTURE_SHADED')
 			
 			
-			if 'CM3D2 Texture Expand' not in mate.keys():
+			if 'CM3D2 Texture Expand' not in mate:
 				mate['CM3D2 Texture Expand'] = True
 			box = self.layout.box()
 			if mate['CM3D2 Texture Expand']:
@@ -549,7 +549,7 @@ class copy_material(bpy.types.Operator):
 		if 'material' in dir(context):
 			mate = context.material
 			if mate:
-				return 'shader1' in mate.keys() and 'shader2' in mate.keys()
+				return 'shader1' in mate and 'shader2' in mate
 		return False
 	
 	def execute(self, context):
@@ -586,7 +586,7 @@ class copy_material(bpy.types.Operator):
 				if img:
 					output_text += '\ttex2d' + "\n"
 					output_text += "\t" + common.remove_serial_number(img.name) + "\n"
-					if 'cm3d2_path' in img.keys():
+					if 'cm3d2_path' in img:
 						path = img['cm3d2_path']
 					else:
 						path = bpy.path.abspath( bpy.path.abspath(img.filepath) )
@@ -623,7 +623,7 @@ class decorate_material(bpy.types.Operator):
 		for slot in ob.material_slots:
 			mate = slot.material
 			if mate:
-				if 'shader1' in mate.keys() and 'shader2' in mate.keys():
+				if 'shader1' in mate and 'shader2' in mate:
 					return True
 		return False
 	
@@ -634,7 +634,7 @@ class decorate_material(bpy.types.Operator):
 		for slot_index, slot in enumerate(ob.material_slots):
 			mate = slot.material
 			if mate:
-				if 'shader1' in mate.keys() and 'shader2' in mate.keys():
+				if 'shader1' in mate and 'shader2' in mate:
 					common.decorate_material(mate, True, me, slot_index)
 		
 		return {'FINISHED'}
@@ -651,7 +651,7 @@ class quick_texture_show(bpy.types.Operator):
 	def poll(cls, context):
 		mate = context.material
 		if mate:
-			if 'shader1' in mate.keys() and 'shader2' in mate.keys():
+			if 'shader1' in mate and 'shader2' in mate:
 				return True
 		return False
 	

--- a/CM3D2 Converter/misc_MESH_MT_shape_key_specials.py
+++ b/CM3D2 Converter/misc_MESH_MT_shape_key_specials.py
@@ -93,7 +93,7 @@ class quick_shape_key_transfer(bpy.types.Operator):
 		for source_shape_key_index, source_shape_key in enumerate(source_me.shape_keys.key_blocks):
 			
 			if target_me.shape_keys:
-				if source_shape_key.name in target_me.shape_keys.key_blocks.keys():
+				if source_shape_key.name in target_me.shape_keys.key_blocks:
 					target_shape_key = target_ob.shape_keys.key_blocks[source_shape_key.name]
 				else:
 					target_shape_key = target_ob.shape_key_add(name=source_shape_key.name, from_mix=False)
@@ -248,7 +248,7 @@ class precision_shape_key_transfer(bpy.types.Operator):
 		for source_shape_key_index, source_shape_key in enumerate(source_me.shape_keys.key_blocks):
 			
 			if target_me.shape_keys:
-				if source_shape_key.name in target_me.shape_keys.key_blocks.keys():
+				if source_shape_key.name in target_me.shape_keys.key_blocks:
 					target_shape_key = target_ob.shape_keys.key_blocks[source_shape_key.name]
 				else:
 					target_shape_key = target_ob.shape_key_add(name=source_shape_key.name, from_mix=False)

--- a/CM3D2 Converter/misc_MESH_MT_vertex_group_specials.py
+++ b/CM3D2 Converter/misc_MESH_MT_vertex_group_specials.py
@@ -83,7 +83,7 @@ class quick_transfer_vertex_group(bpy.types.Operator):
 		context.window_manager.progress_begin(0, len(source_ob.vertex_groups))
 		for source_vertex_group in source_ob.vertex_groups:
 			
-			if source_vertex_group.name in target_ob.vertex_groups.keys():
+			if source_vertex_group.name in target_ob.vertex_groups:
 				target_vertex_group = target_ob.vertex_groups[source_vertex_group.name]
 			else:
 				target_vertex_group = target_ob.vertex_groups.new(source_vertex_group.name)
@@ -228,7 +228,7 @@ class precision_transfer_vertex_group(bpy.types.Operator):
 		context.window_manager.progress_begin(0, len(source_ob.vertex_groups))
 		for source_vertex_group in source_ob.vertex_groups:
 			
-			if source_vertex_group.name in target_ob.vertex_groups.keys():
+			if source_vertex_group.name in target_ob.vertex_groups:
 				target_vertex_group = target_ob.vertex_groups[source_vertex_group.name]
 			else:
 				target_vertex_group = target_ob.vertex_groups.new(source_vertex_group.name)

--- a/CM3D2 Converter/misc_OBJECT_PT_context_object.py
+++ b/CM3D2 Converter/misc_OBJECT_PT_context_object.py
@@ -9,7 +9,7 @@ def menu_func(self, context):
 	if ob.type != 'MESH': return
 	
 	bone_data_count = 0
-	if 'BoneData:0' in ob.keys() and 'LocalBoneData:0' in ob.keys():
+	if 'BoneData:0' in ob and 'LocalBoneData:0' in ob:
 		for key in ob.keys():
 			if re.search(r'^(Local)?BoneData:\d+$', key):
 				bone_data_count += 1
@@ -24,7 +24,7 @@ def menu_func(self, context):
 		row.label(text="CM3D2用ボーン情報", icon_value=common.preview_collections['main']['KISS'].icon_id)
 		sub_row = row.row()
 		sub_row.alignment = 'RIGHT'
-		if 'BoneData:0' in ob.keys() and 'LocalBoneData:0' in ob.keys():
+		if 'BoneData:0' in ob and 'LocalBoneData:0' in ob:
 			bone_data_count = 0
 			for key in ob.keys():
 				if re.search(r'^(Local)?BoneData:\d+$', key):
@@ -47,7 +47,7 @@ class copy_object_bone_data_property(bpy.types.Operator):
 	def poll(cls, context):
 		ob = context.active_object
 		if ob:
-			if 'BoneData:0' in ob.keys() and 'LocalBoneData:0' in ob.keys():
+			if 'BoneData:0' in ob and 'LocalBoneData:0' in ob:
 				return True
 		return False
 	
@@ -55,11 +55,11 @@ class copy_object_bone_data_property(bpy.types.Operator):
 		output_text = ""
 		ob = context.active_object
 		pass_count = 0
-		if 'BaseBone' in ob.keys():
+		if 'BaseBone' in ob:
 			output_text += "BaseBone:" + ob['BaseBone'] + "\n"
 		for i in range(99999):
 			name = "BoneData:" + str(i)
-			if name in ob.keys():
+			if name in ob:
 				output_text += "BoneData:" + ob[name] + "\n"
 			else:
 				pass_count += 1
@@ -68,7 +68,7 @@ class copy_object_bone_data_property(bpy.types.Operator):
 		pass_count = 0
 		for i in range(99999):
 			name = "LocalBoneData:" + str(i)
-			if name in ob.keys():
+			if name in ob:
 				output_text += "LocalBoneData:" + ob[name] + "\n"
 			else:
 				pass_count += 1
@@ -99,7 +99,7 @@ class paste_object_bone_data_property(bpy.types.Operator):
 		pass_count = 0
 		for i in range(99999):
 			name = "BoneData:" + str(i)
-			if name in ob.keys():
+			if name in ob:
 				del ob[name]
 			else:
 				pass_count += 1
@@ -108,7 +108,7 @@ class paste_object_bone_data_property(bpy.types.Operator):
 		pass_count = 0
 		for i in range(99999):
 			name = "LocalBoneData:" + str(i)
-			if name in ob.keys():
+			if name in ob:
 				del ob[name]
 			else:
 				pass_count += 1
@@ -147,7 +147,7 @@ class remove_object_bone_data_property(bpy.types.Operator):
 	def poll(cls, context):
 		ob = context.active_object
 		if ob:
-			if 'BoneData:0' in ob.keys() and 'LocalBoneData:0' in ob.keys():
+			if 'BoneData:0' in ob and 'LocalBoneData:0' in ob:
 				return True
 		return False
 	
@@ -160,11 +160,11 @@ class remove_object_bone_data_property(bpy.types.Operator):
 	def execute(self, context):
 		ob = context.active_object
 		pass_count = 0
-		if 'BaseBone' in ob.keys():
+		if 'BaseBone' in ob:
 			del ob['BaseBone']
 		for i in range(99999):
 			name = "BoneData:" + str(i)
-			if name in ob.keys():
+			if name in ob:
 				del ob[name]
 			else:
 				pass_count += 1
@@ -173,7 +173,7 @@ class remove_object_bone_data_property(bpy.types.Operator):
 		pass_count = 0
 		for i in range(99999):
 			name = "LocalBoneData:" + str(i)
-			if name in ob.keys():
+			if name in ob:
 				del ob[name]
 			else:
 				pass_count += 1

--- a/CM3D2 Converter/misc_RENDER_PT_bake.py
+++ b/CM3D2 Converter/misc_RENDER_PT_bake.py
@@ -77,7 +77,7 @@ class add_bake_image(bpy.types.Operator):
 		
 		image_width, image_height = int(self.image_width), int(self.image_height)
 		
-		if self.image_name in context.blend_data.images.keys():
+		if self.image_name in context.blend_data.images:
 			img = context.blend_data.images[self.image_name]
 		else:
 			img = context.blend_data.images.new(self.image_name, image_width, image_height, alpha=True)
@@ -153,7 +153,7 @@ class quick_ao_bake_image(bpy.types.Operator):
 		
 		image_width, image_height = int(self.image_width), int(self.image_height)
 		
-		if self.image_name in context.blend_data.images.keys():
+		if self.image_name in context.blend_data.images:
 			img = context.blend_data.images[self.image_name]
 		else:
 			img = context.blend_data.images.new(self.image_name, image_width, image_height, alpha=True)
@@ -242,7 +242,7 @@ class quick_dirty_bake_image(bpy.types.Operator):
 		
 		image_width, image_height = int(self.image_width), int(self.image_height)
 		
-		if self.image_name in context.blend_data.images.keys():
+		if self.image_name in context.blend_data.images:
 			img = context.blend_data.images[self.image_name]
 		else:
 			img = context.blend_data.images.new(self.image_name, image_width, image_height, alpha=True)
@@ -341,7 +341,7 @@ class quick_hemi_bake_image(bpy.types.Operator):
 		
 		image_width, image_height = int(self.image_width), int(self.image_height)
 		
-		if self.image_name in context.blend_data.images.keys():
+		if self.image_name in context.blend_data.images:
 			img = context.blend_data.images[self.image_name]
 		else:
 			img = context.blend_data.images.new(self.image_name, image_width, image_height, alpha=True)
@@ -442,7 +442,7 @@ class quick_shadow_bake_image(bpy.types.Operator):
 		
 		image_width, image_height = int(self.image_width), int(self.image_height)
 		
-		if self.image_name in context.blend_data.images.keys():
+		if self.image_name in context.blend_data.images:
 			img = context.blend_data.images[self.image_name]
 		else:
 			img = context.blend_data.images.new(self.image_name, image_width, image_height, alpha=True)
@@ -556,7 +556,7 @@ class quick_side_shadow_bake_image(bpy.types.Operator):
 		
 		image_width, image_height = int(self.image_width), int(self.image_height)
 		
-		if self.image_name in context.blend_data.images.keys():
+		if self.image_name in context.blend_data.images:
 			img = context.blend_data.images[self.image_name]
 		else:
 			img = context.blend_data.images.new(self.image_name, image_width, image_height, alpha=True, float_buffer=True)
@@ -666,7 +666,7 @@ class quick_gradation_bake_image(bpy.types.Operator):
 		
 		image_width, image_height = int(self.image_width), int(self.image_height)
 		
-		if self.image_name in context.blend_data.images.keys():
+		if self.image_name in context.blend_data.images:
 			img = context.blend_data.images[self.image_name]
 		else:
 			img = context.blend_data.images.new(self.image_name, image_width, image_height, alpha=True)
@@ -769,7 +769,7 @@ class quick_metal_bake_image(bpy.types.Operator):
 		
 		image_width, image_height = int(self.image_width), int(self.image_height)
 		
-		if self.image_name in context.blend_data.images.keys():
+		if self.image_name in context.blend_data.images:
 			img = context.blend_data.images[self.image_name]
 		else:
 			img = context.blend_data.images.new(self.image_name, image_width, image_height, alpha=True)
@@ -892,7 +892,7 @@ class quick_hair_bake_image(bpy.types.Operator):
 		
 		image_width, image_height = int(self.image_width), int(self.image_height)
 		
-		if self.image_name in context.blend_data.images.keys():
+		if self.image_name in context.blend_data.images:
 			img = context.blend_data.images[self.image_name]
 		else:
 			img = context.blend_data.images.new(self.image_name, image_width, image_height, alpha=True)
@@ -1022,7 +1022,7 @@ class quick_uv_border_bake_image(bpy.types.Operator):
 		
 		image_width, image_height = int(self.image_width), int(self.image_height)
 		
-		if self.image_name in context.blend_data.images.keys():
+		if self.image_name in context.blend_data.images:
 			img = context.blend_data.images[self.image_name]
 		else:
 			img = context.blend_data.images.new(self.image_name, image_width, image_height, alpha=True)
@@ -1180,7 +1180,7 @@ class quick_mesh_border_bake_image(bpy.types.Operator):
 		
 		image_width, image_height = int(self.image_width), int(self.image_height)
 		
-		if self.image_name in context.blend_data.images.keys():
+		if self.image_name in context.blend_data.images:
 			img = context.blend_data.images[self.image_name]
 		else:
 			img = context.blend_data.images.new(self.image_name, image_width, image_height, alpha=True)
@@ -1296,7 +1296,7 @@ class quick_density_bake_image(bpy.types.Operator):
 		
 		image_width, image_height = int(self.image_width), int(self.image_height)
 		
-		if self.image_name in context.blend_data.images.keys():
+		if self.image_name in context.blend_data.images:
 			img = context.blend_data.images[self.image_name]
 		else:
 			img = context.blend_data.images.new(self.image_name, image_width, image_height, alpha=True)
@@ -1439,7 +1439,7 @@ class quick_mesh_distance_bake_image(bpy.types.Operator):
 		
 		image_width, image_height = int(self.image_width), int(self.image_height)
 		
-		if self.image_name in context.blend_data.images.keys():
+		if self.image_name in context.blend_data.images:
 			img = context.blend_data.images[self.image_name]
 		else:
 			img = context.blend_data.images.new(self.image_name, image_width, image_height, alpha=True)
@@ -1537,7 +1537,7 @@ class quick_bulge_bake_image(bpy.types.Operator):
 		
 		image_width, image_height = int(self.image_width), int(self.image_height)
 		
-		if self.image_name in context.blend_data.images.keys():
+		if self.image_name in context.blend_data.images:
 			img = context.blend_data.images[self.image_name]
 		else:
 			img = context.blend_data.images.new(self.image_name, image_width, image_height, alpha=True)
@@ -1647,7 +1647,7 @@ class quick_semen_bake_image(bpy.types.Operator):
 		
 		image_width, image_height = int(self.image_width), int(self.image_height)
 		
-		if self.image_name in context.blend_data.images.keys():
+		if self.image_name in context.blend_data.images:
 			img = context.blend_data.images[self.image_name]
 		else:
 			img = context.blend_data.images.new(self.image_name, image_width, image_height, alpha=True)

--- a/CM3D2 Converter/misc_RENDER_PT_render.py
+++ b/CM3D2 Converter/misc_RENDER_PT_render.py
@@ -54,7 +54,7 @@ class render_cm3d2_icon(bpy.types.Operator):
 		else:
 			self.mode = 'NOW_MATERIAL'
 		
-		if 'render_cm3d2_icon_background_color' in context.scene.keys():
+		if 'render_cm3d2_icon_background_color' in context.scene:
 			try:
 				color = str( context.scene['render_cm3d2_icon_background_color'] ).split(",")
 				if len(color) == 3:
@@ -62,7 +62,7 @@ class render_cm3d2_icon(bpy.types.Operator):
 					self.background_color[1] = float(color[1])
 					self.background_color[2] = float(color[2])
 			except: pass
-		if 'render_cm3d2_icon_background_color_layer_image' in context.scene.keys(): self.layer_image = context.scene['render_cm3d2_icon_background_color_layer_image']
+		if 'render_cm3d2_icon_background_color_layer_image' in context.scene: self.layer_image = context.scene['render_cm3d2_icon_background_color_layer_image']
 		
 		return context.window_manager.invoke_props_dialog(self)
 	
@@ -213,7 +213,7 @@ class render_cm3d2_icon(bpy.types.Operator):
 		img_node = node_tree.nodes.new('CompositorNodeImage')
 		img_node.location = (0, -300)
 		blend_path = os.path.join(os.path.dirname(__file__), "append_data.blend")
-		if "Icon Alpha" in context.blend_data.images.keys():
+		if "Icon Alpha" in context.blend_data.images:
 			icon_alpha_img = context.blend_data.images["Icon Alpha"]
 		else:
 			with context.blend_data.libraries.load(blend_path) as (data_from, data_to):
@@ -236,7 +236,7 @@ class render_cm3d2_icon(bpy.types.Operator):
 		out_node.location = (1500, 0)
 		
 		layer_img = None
-		if self.layer_image in context.blend_data.images.keys():
+		if self.layer_image in context.blend_data.images:
 			layer_img = context.blend_data.images[self.layer_image]
 		if layer_img:
 			layer_img_node = node_tree.nodes.new('CompositorNodeImage')

--- a/CM3D2 Converter/misc_TEXTURE_PT_context_texture.py
+++ b/CM3D2 Converter/misc_TEXTURE_PT_context_texture.py
@@ -47,7 +47,7 @@ def menu_func(self, context):
 					row = sub_box.split(percentage=0.333333333333, align=True)
 					row.label(text="テクスチャ名:")
 					row.template_ID(tex, 'image', open='image.open')
-					if 'cm3d2_path' not in img.keys():
+					if 'cm3d2_path' not in img:
 						img['cm3d2_path'] = "Assets\\texture\\texture\\" + os.path.basename(img.filepath)
 					sub_box.prop(img, '["cm3d2_path"]', text="テクスチャパス")
 					
@@ -279,7 +279,7 @@ class show_image(bpy.types.Operator):
 	image_name = bpy.props.StringProperty(name="画像名")
 	
 	def execute(self, context):
-		if self.image_name in context.blend_data.images.keys():
+		if self.image_name in context.blend_data.images:
 			img = context.blend_data.images[self.image_name]
 		else:
 			self.report(type={'ERROR'}, message="指定された画像が見つかりません")
@@ -332,7 +332,7 @@ class sync_tex_color_ramps(bpy.types.Operator):
 	
 	def execute(self, context):
 		for mate in context.blend_data.materials:
-			if 'shader1' in mate.keys() and 'shader2' in mate.keys():
+			if 'shader1' in mate and 'shader2' in mate:
 				for slot in mate.texture_slots:
 					if not slot:
 						continue
@@ -515,7 +515,7 @@ class quick_export_cm3d2_tex(bpy.types.Operator):
 		override['edit_image'] = img
 		filepath = os.path.splitext( bpy.path.abspath(img.filepath) )[0] + ".tex"
 		path = "assets/texture/texture/" + os.path.basename( bpy.path.abspath(img.filepath) )
-		if 'cm3d2_path' in img.keys():
+		if 'cm3d2_path' in img:
 			path = img['cm3d2_path']
 		if os.path.exists(filepath):
 			file = open(filepath, 'rb')

--- a/CM3D2 Converter/misc_TEXT_HT_header.py
+++ b/CM3D2 Converter/misc_TEXT_HT_header.py
@@ -22,8 +22,8 @@ def menu_func(self, context):
 				line_count += 1
 		row.operator('text.show_text', icon='BONE_DATA', text="LocalBoneData (%d)" % line_count).name = 'LocalBoneData'
 	if 'BoneData' in text_keys and 'LocalBoneData' in text_keys:
-		if 'BoneData' in texts.keys():
-			if 'BaseBone' not in texts['BoneData'].keys():
+		if 'BoneData' in texts:
+			if 'BaseBone' not in texts['BoneData']:
 				texts['BoneData']['BaseBone'] = ""
 			row.prop(texts['BoneData'], '["BaseBone"]', text="")
 		row.operator('text.copy_text_bone_data', icon='COPYDOWN', text="")
@@ -72,11 +72,11 @@ class copy_text_bone_data(bpy.types.Operator):
 	@classmethod
 	def poll(cls, context):
 		texts = context.blend_data.texts
-		return 'BoneData' in texts.keys() and 'LocalBoneData' in texts.keys()
+		return 'BoneData' in texts and 'LocalBoneData' in texts
 	
 	def execute(self, context):
 		output_text = ""
-		if 'BaseBone' in context.blend_data.texts['BoneData'].keys():
+		if 'BaseBone' in context.blend_data.texts['BoneData']:
 			output_text += "BaseBone:" + context.blend_data.texts['BoneData']['BaseBone'] + "\n"
 		for line in context.blend_data.texts['BoneData'].as_string().split('\n'):
 			if not line:
@@ -104,12 +104,12 @@ class paste_text_bone_data(bpy.types.Operator):
 	def execute(self, context):
 		import re
 		clipboard = context.window_manager.clipboard
-		if "BoneData" in context.blend_data.texts.keys():
+		if "BoneData" in context.blend_data.texts:
 			bone_data_text = context.blend_data.texts["BoneData"]
 			bone_data_text.clear()
 		else:
 			bone_data_text = context.blend_data.texts.new("BoneData")
-		if "LocalBoneData" in context.blend_data.texts.keys():
+		if "LocalBoneData" in context.blend_data.texts:
 			local_bone_data_text = context.blend_data.texts["LocalBoneData"]
 			local_bone_data_text.clear()
 		else:
@@ -145,7 +145,7 @@ class remove_all_material_texts(bpy.types.Operator):
 	
 	@classmethod
 	def poll(cls, context):
-		return 'Material:0' in context.blend_data.texts.keys()
+		return 'Material:0' in context.blend_data.texts
 	
 	def invoke(self, context, event):
 		return context.window_manager.invoke_props_dialog(self)
@@ -158,7 +158,7 @@ class remove_all_material_texts(bpy.types.Operator):
 		pass_count = 0
 		for i in range(9999):
 			name = 'Material:' + str(i)
-			if name in context.blend_data.texts.keys():
+			if name in context.blend_data.texts:
 				remove_texts.append(context.blend_data.texts[name])
 			else:
 				pass_count += 1

--- a/CM3D2 Converter/model_export.py
+++ b/CM3D2 Converter/model_export.py
@@ -84,9 +84,9 @@ class export_cm3d2_model(bpy.types.Operator):
 		
 		# ボーン情報元のデフォルトオプションを取得
 		if self.bone_info_mode == 'OBJECT':
-			if "BoneData:0" not in ob.keys():
-				if "BoneData" in context.blend_data.texts.keys():
-					if "LocalBoneData" in context.blend_data.texts.keys():
+			if "BoneData:0" not in ob:
+				if "BoneData" in context.blend_data.texts:
+					if "LocalBoneData" in context.blend_data.texts:
 						self.bone_info_mode = 'TEXT'
 				arm_ob = ob.parent
 				if arm_ob:
@@ -161,14 +161,14 @@ class export_cm3d2_model(bpy.types.Operator):
 		
 		# データの成否チェック
 		if self.bone_info_mode == 'TEXT':
-			if "BoneData" not in context.blend_data.texts.keys():
+			if "BoneData" not in context.blend_data.texts:
 				return self.report_cancel("テキスト「BoneData」が見つかりません、中止します")
-			if "LocalBoneData" not in context.blend_data.texts.keys():
+			if "LocalBoneData" not in context.blend_data.texts:
 				return self.report_cancel("テキスト「LocalBoneData」が見つかりません、中止します")
 		elif self.bone_info_mode == 'OBJECT':
-			if "BoneData:0" not in ob.keys():
+			if "BoneData:0" not in ob:
 				return self.report_cancel("オブジェクトのカスタムプロパティにボーン情報がありません")
-			if "LocalBoneData:0" not in ob.keys():
+			if "LocalBoneData:0" not in ob:
 				return self.report_cancel("オブジェクトのカスタムプロパティにボーン情報がありません")
 		elif self.bone_info_mode == 'ARMATURE':
 			arm_ob = ob.parent
@@ -180,16 +180,16 @@ class export_cm3d2_model(bpy.types.Operator):
 				except StopIteration:
 					return self.report_cancel("アーマチュアが見つかりません、親にするかモディファイアにして下さい")
 				arm_ob = arm_ob.object
-			if "BoneData:0" not in arm_ob.data.keys():
+			if "BoneData:0" not in arm_ob.data:
 				return self.report_cancel("アーマチュアのカスタムプロパティにボーン情報がありません")
-			if "LocalBoneData:0" not in arm_ob.data.keys():
+			if "LocalBoneData:0" not in arm_ob.data:
 				return self.report_cancel("アーマチュアのカスタムプロパティにボーン情報がありません")
 		else:
 			return self.report_cancel("ボーン情報元のモードがおかしいです")
 		
 		if self.mate_info_mode == 'TEXT':
 			for index, slot in enumerate(ob.material_slots):
-				if "Material:" + str(index) not in context.blend_data.texts.keys():
+				if "Material:" + str(index) not in context.blend_data.texts:
 					return self.report_cancel("マテリアル情報元のテキストが足りません")
 		context.window_manager.progress_update(1)
 		
@@ -204,7 +204,7 @@ class export_cm3d2_model(bpy.types.Operator):
 		base_bone_candidate = None
 		bone_data = []
 		if self.bone_info_mode == 'TEXT':
-			if 'BaseBone' in context.blend_data.texts["BoneData"].keys():
+			if 'BaseBone' in context.blend_data.texts["BoneData"]:
 				base_bone_candidate = context.blend_data.texts["BoneData"]['BaseBone']
 			for line in context.blend_data.texts["BoneData"].lines:
 				data = line.body.split(',')
@@ -234,12 +234,12 @@ class export_cm3d2_model(bpy.types.Operator):
 				target = ob
 			elif self.bone_info_mode == 'ARMATURE':
 				target = arm_ob.data
-			if 'BaseBone' in target.keys():
+			if 'BaseBone' in target:
 				base_bone_candidate = target['BaseBone']
 			pass_count = 0
 			for i in range(9**9):
 				name = "BoneData:" + str(i)
-				if name not in target.keys():
+				if name not in target:
 					pass_count += 1
 					if 50 < pass_count:
 						break
@@ -301,7 +301,7 @@ class export_cm3d2_model(bpy.types.Operator):
 					target = ob
 				elif self.bone_info_mode == 'ARMATURE':
 					target = arm_ob.data
-				if name not in target.keys():
+				if name not in target:
 					pass_count += 1
 					if 50 < pass_count:
 						break
@@ -590,7 +590,7 @@ class export_cm3d2_model(bpy.types.Operator):
 							img = tex.image
 							common.write_str(file, 'tex2d')
 							common.write_str(file, common.remove_serial_number(img.name, self.is_arrange_name))
-							if 'cm3d2_path' in img.keys():
+							if 'cm3d2_path' in img:
 								path = img['cm3d2_path']
 							else:
 								path = bpy.path.abspath(img.filepath)

--- a/CM3D2 Converter/model_import.py
+++ b/CM3D2 Converter/model_import.py
@@ -277,7 +277,7 @@ class import_cm3d2_model(bpy.types.Operator):
 				if len(child_data) <= 0:
 					break
 				data = child_data.pop(0)
-				if common.decode_bone_name(data['parent_name'], self.is_convert_bone_weight_names) in arm.edit_bones.keys():
+				if common.decode_bone_name(data['parent_name'], self.is_convert_bone_weight_names) in arm.edit_bones:
 					bone = arm.edit_bones.new(common.decode_bone_name(data['name'], self.is_convert_bone_weight_names))
 					parent = arm.edit_bones[common.decode_bone_name(data['parent_name'], self.is_convert_bone_weight_names)]
 					bone.parent = parent
@@ -580,7 +580,7 @@ class import_cm3d2_model(bpy.types.Operator):
 		if self.is_mate_data_text:
 			for index, data in enumerate(material_data):
 				txt_name = "Material:" + str(index)
-				if txt_name in context.blend_data.texts.keys():
+				if txt_name in context.blend_data.texts:
 					txt = context.blend_data.texts[txt_name]
 					txt.clear()
 				else:
@@ -613,7 +613,7 @@ class import_cm3d2_model(bpy.types.Operator):
 		
 		# ボーン情報のテキスト埋め込み
 		if self.is_bone_data_text:
-			if "BoneData" in context.blend_data.texts.keys():
+			if "BoneData" in context.blend_data.texts:
 				txt = context.blend_data.texts["BoneData"]
 				txt.clear()
 			else:
@@ -641,7 +641,7 @@ class import_cm3d2_model(bpy.types.Operator):
 		
 		# ローカルボーン情報のテキスト埋め込み
 		if self.is_bone_data_text:
-			if "LocalBoneData" in context.blend_data.texts.keys():
+			if "LocalBoneData" in context.blend_data.texts:
 				txt = context.blend_data.texts["LocalBoneData"]
 				txt.clear()
 			else:

--- a/CM3D2 Converter/tex_export.py
+++ b/CM3D2 Converter/tex_export.py
@@ -33,11 +33,11 @@ class export_cm3d2_tex(bpy.types.Operator):
 		else:
 			self.filepath = common.default_cm3d2_dir(common.preferences().tex_export_path, common.remove_serial_number(img.name), "tex")
 		self.is_backup = bool(common.preferences().backup_ext)
-		if 'cm3d2_path' in img.keys():
+		if 'cm3d2_path' in img:
 			self.path = img['cm3d2_path']
 		else:
 			self.path = "assets/texture/texture/" + os.path.basename(self.filepath)
-		if 'tex Name' in img.keys():
+		if 'tex Name' in img:
 			self.filepath = os.path.join(os.path.dirname(self.filepath), img['tex Name'])
 		context.window_manager.fileselect_add(self)
 		return {'RUNNING_MODAL'}


### PR DESCRIPTION
`dict` 内の key チェックや、Blender の `bpy_prop_collection` type 内の要素名チェック時に `_.keys()` を利用しない。
上記は `key in dict` や `name in collection` で存在確認が可能です。
`_.keys()` を経由すると一度 `list` を生成するため遅くなります。
