### PR TITLE
エクスポート時にアトミックにファイル更新する

### DIFF
--- a/CM3D2 Converter/anm_export.py
+++ b/CM3D2 Converter/anm_export.py
@@ -1,4 +1,5 @@
-import os, re, bpy, math, struct, os.path, mathutils
+import bpy
+import struct
 from . import common
 
 # メインオペレーター
@@ -50,11 +51,12 @@ class export_cm3d2_anm(bpy.types.Operator):
 			self.report(type={'ERROR'}, message="ファイルを開くのに失敗しました、アクセス不可の可能性があります")
 			return {'CANCELLED'}
 		
-		with file:
-			res = self.write_animation(context, file)
-			if res:
-				file.abort()
-				return res
+		try:
+			with file:
+				self.write_animation(context, file)
+		except common.CM3D2ExportException as e:
+			self.report(type={'ERROR'}, message=str(e))
+			return {'CANCELLED'}
 		
 		return {'FINISHED'}
 		

--- a/CM3D2 Converter/common.py
+++ b/CM3D2 Converter/common.py
@@ -1,4 +1,5 @@
 import bpy, os, re, math, bmesh, struct, shutil, mathutils
+from . import fileutil
 
 addon_name = "CM3D2 Converter"
 preview_collections = {}
@@ -331,6 +332,15 @@ def default_cm3d2_dir(base_dir, file_name, new_ext):
 		base_dir = os.path.join(os.path.split(base_dir)[0], file_name)
 	base_dir = os.path.splitext(base_dir)[0] + "." + new_ext
 	return base_dir
+
+# 一時ファイル書き込みと自動バックアップを行うファイルオブジェクトを返す
+def open_temporary(filepath, mode, is_backup=False):
+	backup_ext = preferences().backup_ext
+	if is_backup and backup_ext:
+		backup_filepath = filepath + '.' + backup_ext
+	else:
+		backup_filepath = None
+	return fileutil.TemporaryFileWriter(filepath, mode, backup_filepath=backup_filepath)
 
 # ファイルを上書きするならバックアップ処理
 def file_backup(filepath, enable=True):

--- a/CM3D2 Converter/common.py
+++ b/CM3D2 Converter/common.py
@@ -612,3 +612,7 @@ def in_out_quad_blend(f):
 # スムーズなグラフを返す2
 def bezier_blend(f):
 	return math.sqrt(f) * (3.0 - 2.0 * f)
+
+# エクスポート例外クラス
+class CM3D2ExportException(Exception):
+	pass

--- a/CM3D2 Converter/fileutil.py
+++ b/CM3D2 Converter/fileutil.py
@@ -1,0 +1,83 @@
+import io
+import os
+import shutil
+import tempfile
+
+
+
+class TemporaryFileWriter(io.BufferedWriter):
+    """ファイルをアトミックに更新します。"""
+
+    backup_filepath = None
+    __filepath = None
+    __temppath = None
+
+
+    @property
+    def filepath(self):
+        """ファイルパスを取得します。"""
+        return self.__filepath
+
+
+    @property
+    def temppath(self):
+        """一時ファイルパスを取得します。"""
+        return self.__temppath
+
+
+    def __init__(self, filepath, mode='wb', buffer_size=io.DEFAULT_BUFFER_SIZE, backup_filepath=None):
+        """ファイルパスを指定して初期化します。
+        backup_filepath に None 以外が指定された場合、書き込み完了時に
+        バックアップファイルが作成されます。
+        """
+        dirpath, filename = os.path.split(filepath)
+        fd, temppath = tempfile.mkstemp(prefix=filename + '.', dir=dirpath)
+        try:
+            fh = os.fdopen(fd, mode)
+            super(TemporaryFileWriter, self).__init__(fh, buffer_size)
+        except:
+            if fh:
+                fh.close()
+            os.remove(temppath)
+            raise
+        self.__filepath = filepath
+        self.__temppath = temppath
+        self.backup_filepath = backup_filepath
+
+
+    def __enter__(self):
+        return self
+
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if exc_type is None and exc_value is None and traceback is None:
+            self.close()
+        else:
+            self.abort()
+
+
+    def close(self):
+        """一時ファイルを閉じてリネームします。"""
+        if self.closed:
+            return
+        super(io.BufferedWriter, self).close()
+        self.raw.close()
+        try:
+            if os.path.exists(self.filepath):
+                if self.backup_filepath is not None:
+                    shutil.move(self.filepath, self.backup_filepath)
+                else:
+                    os.remove(self.filepath)
+            shutil.move(self.temppath, self.filepath)
+        except:
+            os.remove(self.temppath)
+            raise
+
+
+    def abort(self):
+        """一時ファイルを閉じて削除します。"""
+        if self.closed:
+            return
+        super(io.BufferedWriter, self).close()
+        self.raw.close()
+        os.remove(self.temppath)

--- a/CM3D2 Converter/mate_export.py
+++ b/CM3D2 Converter/mate_export.py
@@ -1,4 +1,7 @@
-import os, re, bpy, struct, os.path
+import bpy
+import os
+import re
+import struct
 from . import common
 
 class export_cm3d2_mate(bpy.types.Operator):
@@ -56,11 +59,12 @@ class export_cm3d2_mate(bpy.types.Operator):
 			self.report(type={'ERROR'}, message="ファイルを開くのに失敗しました、アクセス不可の可能性があります")
 			return {'CANCELLED'}
 		
-		with file:
-			res = self.write_material(context, file)
-			if res:
-				file.abort()
-				return res
+		try:
+			with file:
+				self.write_material(context, file)
+		except common.CM3D2ExportException as e:
+			self.report(type={'ERROR'}, message=str(e))
+			return {'CANCELLED'}
 		
 		return {'FINISHED'}
 
@@ -92,8 +96,7 @@ class export_cm3d2_mate(bpy.types.Operator):
 				try:
 					img = tex.image
 				except:
-					self.report(type={'ERROR'}, message="texタイプの設定値の取得に失敗しました、中止します")
-					return {'CANCELLED'}
+					raise common.CM3D2ExportException("texタイプの設定値の取得に失敗しました、中止します")
 				if img:
 					common.write_str(file, 'tex2d')
 					common.write_str(file, common.remove_serial_number(img.name))
@@ -189,11 +192,12 @@ class export_cm3d2_mate_text(bpy.types.Operator):
 			self.report(type={'ERROR'}, message="ファイルを開くのに失敗しました、アクセス不可の可能性があります")
 			return {'CANCELLED'}
 		
-		with file:
-			res = self.write_material(context, file)
-			if res:
-				file.abort()
-				return res
+		try:
+			with file:
+				self.write_material(context, file)
+		except common.CM3D2ExportException as e:
+			self.report(type={'ERROR'}, message=str(e))
+			return {'CANCELLED'}
 		
 		return {'FINISHED'}
 
@@ -243,11 +247,9 @@ class export_cm3d2_mate_text(bpy.types.Operator):
 					file.write(struct.pack('<f', f))
 					line_seek += 3
 				else:
-					self.report(type={'ERROR'}, message="tex col f 以外の設定値が見つかりました、中止します")
-					return {'CANCELLED'}
+					raise common.CM3D2ExportException("tex col f 以外の設定値が見つかりました、中止します")
 		except:
-			self.report(type={'ERROR'}, message="mateファイルの出力に失敗、中止します。 構文を見直して下さい")
-			return {'CANCELLED'}
+			raise common.CM3D2ExportException("mateファイルの出力に失敗、中止します。 構文を見直して下さい")
 		common.write_str(file, 'end')
 
 # テキストメニューに項目を登録

--- a/CM3D2 Converter/tex_export.py
+++ b/CM3D2 Converter/tex_export.py
@@ -1,4 +1,4 @@
-import os, re, bpy, struct, os.path, shutil
+import os, bpy, struct, os.path
 from . import common
 
 class export_cm3d2_tex(bpy.types.Operator):
@@ -53,9 +53,21 @@ class export_cm3d2_tex(bpy.types.Operator):
 	def execute(self, context):
 		common.preferences().tex_export_path = self.filepath
 		
-		# バックアップ
-		common.file_backup(self.filepath, self.is_backup)
+		try:
+			file = common.open_temporary(self.filepath, 'wb', is_backup=self.is_backup)
+		except:
+			self.report(type={'ERROR'}, message="ファイルを開くのに失敗しました、アクセス不可の可能性があります")
+			return {'CANCELLED'}
 		
+		with file:
+			res = self.write_texture(context, file)
+			if res:
+				file.abort()
+				return res
+		
+		return {'FINISHED'}
+
+	def write_texture(self, context, file):
 		# とりあえずpngで保存
 		img = context.edit_image
 		if img.source != 'VIEWER':
@@ -83,27 +95,18 @@ class export_cm3d2_tex(bpy.types.Operator):
 			img.source = pre_source
 		
 		# pngバイナリを全て読み込み
-		temp_file = open(temp_path, 'rb')
-		temp_data = temp_file.read()
-		temp_file.close()
+		with open(temp_path, 'rb') as temp_file:
+			temp_data = temp_file.read()
 		# 一時ファイルを削除
 		if is_remove:
 			os.remove(temp_path)
 		
 		# 本命ファイルに書き込み
-		try:
-			file = open(self.filepath, 'wb')
-		except:
-			self.report(type={'ERROR'}, message="ファイルを開くのに失敗しました、アクセス不可の可能性があります")
-			return {'CANCELLED'}
 		common.write_str(file, 'CM3D2_TEX')
 		file.write(struct.pack('<i', self.version))
 		common.write_str(file, self.path)
 		file.write(struct.pack('<i', len(temp_data)))
 		file.write(temp_data)
-		file.close()
-		
-		return {'FINISHED'}
 
 # メニューを登録する関数
 def menu_func(self, context):

--- a/CM3D2 Converter/tex_export.py
+++ b/CM3D2 Converter/tex_export.py
@@ -1,4 +1,6 @@
-import os, bpy, struct, os.path
+import bpy
+import os
+import struct
 from . import common
 
 class export_cm3d2_tex(bpy.types.Operator):
@@ -59,11 +61,12 @@ class export_cm3d2_tex(bpy.types.Operator):
 			self.report(type={'ERROR'}, message="ファイルを開くのに失敗しました、アクセス不可の可能性があります")
 			return {'CANCELLED'}
 		
-		with file:
-			res = self.write_texture(context, file)
-			if res:
-				file.abort()
-				return res
+		try:
+			with file:
+				self.write_texture(context, file)
+		except common.CM3D2ExportException as e:
+			self.report(type={'ERROR'}, message=str(e))
+			return {'CANCELLED'}
 		
 		return {'FINISHED'}
 
@@ -88,8 +91,7 @@ class export_cm3d2_tex(bpy.types.Operator):
 				temp_path = bpy.path.abspath(img.filepath)
 				is_remove = False
 			else:
-				self.report(type={'ERROR'}, message="PNGファイルの取得に失敗しました")
-				return {'CANCELLED'}
+				raise common.CM3D2ExportException("PNGファイルの取得に失敗しました")
 		if pre_source != 'VIEWER':
 			img.filepath = pre_filepath
 			img.source = pre_source


### PR DESCRIPTION
エクスポート途中でエラーが発生すると破損ファイルが生成されます。
出力時に一時ファイルに書き出し、最後にリネームを行うことで成功時だけファイルが生成されるようにしました。
