### PR TITLE
ポーズ素体化処理のNoneチェック追加と、クリップボードからマテリアル上書き追加

### DIFF
--- a/CM3D2 Converter/misc_VIEW3D_MT_pose_apply.py
+++ b/CM3D2 Converter/misc_VIEW3D_MT_pose_apply.py
@@ -48,7 +48,7 @@ class apply_prime_field(bpy.types.Operator):
 					is_applies = [False] * 32
 					for i, mod in enumerate(o.modifiers):
 						if mod.type == 'ARMATURE':
-							if mod.object.name == ob.name:
+							if mod.object and mod.object.name == ob.name:
 								is_applies[i] = True
 								if self.is_deform_preserve_volume:
 									mod.use_deform_preserve_volume = True


### PR DESCRIPTION
２点変更しました。
・ポーズの素体化時に例外で止まるケースがあったのを修正
・クリップボードからのマテリアル追加は既にありますが、
　手早く貼り付けられるよう、クリップボードからマテリアル情報の上書きを追加しました。

後者は、個人的な好みで追加してしまったので、Converterの機能にそぐわない場合は却下お願いします。
