### PR TITLE
配列の配列初期化で同一オブジェクトを複製してしまっていたのを修正。

### DIFF
--- a/CM3D2 Converter/model_export.py
+++ b/CM3D2 Converter/model_export.py
@@ -581,7 +581,7 @@ class export_cm3d2_model(bpy.types.Operator):
 							tris.append([seek_min, seek_max-1, seek_max])
 							seek_max -= 1
 					
-					tris_indexs = [[]] * len(tris)
+					tris_indexs = [[] for _ in range(len(tris))]
 					for i, vert_index in enumerate(vert_index_from_loops(reversed(face.loops))):
 						for tris_index, points in enumerate(tris):
 							if i in points:


### PR DESCRIPTION
前回のPRで5角形以上の面の書き出しにバグがありました。
申し訳ありません。